### PR TITLE
Small Tweaks to PHP Version

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -5,5 +5,5 @@ See the [top level readme](https://github.com/emilybache/Theatrical-Players-Refa
 
 This project uses [PHPUnit](https://github.com/sebastianbergmann/phpunit) and [approvaltests](https://github.com/approvals/ApprovalTests.php). 
 
-Run ```composer install``` then ```./vendor/phpunit tests/StatementPrinterTest.php``` to run the tests
+Run ```composer install``` then ```./vendor/bin/phpunit``` to run the tests
 

--- a/php/composer.json
+++ b/php/composer.json
@@ -11,7 +11,9 @@
             "email": "sam@cranford.fr"
         }
     ],
-    "require": {},
+    "require": {
+      "php": "^7.4"
+    },
     "autoload": {
         "psr-4": {
             "Theatrical\\": "src/"

--- a/php/composer.lock
+++ b/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77491cb9611136e36e9bf34ba80ac7cd",
+    "content-hash": "debf9e449f433ef7677ba20d6f2ef030",
     "packages": [],
     "packages-dev": [
         {
@@ -342,41 +342,38 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
-                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/a48807183a4b819072f26e347bbd0b5199a9d15f",
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpdocumentor/type-resolver": "0.4.*",
-                "phpunit/phpunit": "^6.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -387,10 +384,14 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-12-28T18:55:12+00:00"
+            "time": "2020-02-09T09:16:15+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1669,6 +1670,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^7.4"
+    },
     "platform-dev": []
 }

--- a/php/phpunit.xml
+++ b/php/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/php/tests/StatementPrinterTest.php
+++ b/php/tests/StatementPrinterTest.php
@@ -10,7 +10,7 @@ use Theatrical\Invoice;
 
 final class StatementPrinterTest extends TestCase
 {
-    public function testCanPrintInvoice() : void 
+    public function testCanPrintInvoice() : void
     {
         $plays = [
             "hamlet" => new Play("Hamlet", "tragedy"),
@@ -27,10 +27,10 @@ final class StatementPrinterTest extends TestCase
         $statementPrinter = new StatementPrinter();
         $result = $statementPrinter->print($invoice, $plays);
 
-        Approvals::approveString($result);  
+        Approvals::verifyString($result);
     }
 
-    public function testNewPlayTypes() : void 
+    public function testNewPlayTypes() : void
     {
         $plays = [
             "henry-v" => new Play("Henry V", "history"),


### PR DESCRIPTION
First, thanks for doing most of the heavy lifting on this version of the kata. I was going to do it this morning myself and saw you had already beat me to it.

I hope you don't mind but I made a few small tweaks to the branch, I'd appreciate your consideration in including them in the official PR to Emily's repo.

- I set the minimum required version of PHP to 7.4 since this repo is using typed properties
- I added a phpunit.xml file to make running the tests a little easier and to support gathering code coverage
- PHPStorm told me that `approveString` was deprecated so I replaced it with `verifyString`

Again, awesome work and thanks!